### PR TITLE
Revert "🐛 fix deprecated warning"

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -217,7 +217,7 @@ async function run(): Promise<void> {
   const diffs: Diff[] = [];
 
   await asyncForEach(apps, async app => {
-    const command = `app diff ${app.metadata.name} --local=${app.spec.source.path} --server-side-generate`;
+    const command = `app diff ${app.metadata.name} --local=${app.spec.source.path}`;
     try {
       core.info(`Running: argocd ${command}`);
       // ArgoCD app diff will exit 1 if there is a diff, so always catch,


### PR DESCRIPTION
This reverts commit 96fb25d0203d6d48211097f1ed459a8f05bcac7e.
The orignal commit breaks the command with a checksum issue which isn't resolved yet (cf: https://github.com/argoproj/argo-cd/issues/8145)